### PR TITLE
23-hide-lighttotal-input-to-formdatamonth

### DIFF
--- a/src/components/MetersData/MetersData.tsx
+++ b/src/components/MetersData/MetersData.tsx
@@ -13,6 +13,12 @@ export const MetersData: React.FC<MetersDataProps> = ({
   isWaterBlock = true,
 }) => {
   const lang = useAppSelector(selectTranslations);
+
+  const [hideTotalLight, setHideTotalLight] = React.useState(false);
+
+  const toggleHideTotalLight = () => {
+    setHideTotalLight((prevState) => !prevState);
+  };
   return (
     <section className={Styles.metersData}>
       <div className="overflow-auto">
@@ -25,7 +31,13 @@ export const MetersData: React.FC<MetersDataProps> = ({
           }
           :
         </h4>
-        <FormDataMonth isWaterBlock={isWaterBlock} />
+        <button onClick={toggleHideTotalLight}>
+          {!hideTotalLight ? "Show Total Light" : "Hide Total Light"}
+        </button>
+        <FormDataMonth
+          isWaterBlock={isWaterBlock}
+          hideTotalLight={hideTotalLight}
+        />
         <h4 className={Styles.title}>
           <BsCalendar3 style={{ marginRight: "10px" }} />
           {lang.metersData["Meter Reading Data Table by Months"]}:

--- a/src/ui/MetersData/FormDataMonth/FormDataMonth.tsx
+++ b/src/ui/MetersData/FormDataMonth/FormDataMonth.tsx
@@ -27,10 +27,12 @@ import { SIZE_ICONS } from "@/constants/sizeIcons";
 
 interface FormDataMonthProps {
   isWaterBlock: boolean;
+  hideTotalLight?: boolean;
 }
 
 export const FormDataMonth: React.FC<FormDataMonthProps> = ({
   isWaterBlock,
+  hideTotalLight = true,
 }) => {
   const { pathname } = useLocation();
   const dispatch = useAppDispatch();
@@ -237,19 +239,21 @@ export const FormDataMonth: React.FC<FormDataMonthProps> = ({
           value={valueSelectDate}
           onChange={onChange}
         />
-        <Input
-          className={Style.input}
-          style={isEdit ? { backgroundColor: COLORS.lightGreen } : {}}
-          labelTextBold
-          defaultValue={
-            isEdit && meterDataEdit
-              ? meterDataEdit?.light
-              : setDefaultValue("light")
-          }
-          labelText={lang.infoPanel["Light general"]}
-          value={light}
-          setValue={setLight}
-        />
+        {hideTotalLight && (
+          <Input
+            className={Style.input}
+            style={isEdit ? { backgroundColor: COLORS.lightGreen } : {}}
+            labelTextBold
+            defaultValue={
+              isEdit && meterDataEdit
+                ? meterDataEdit?.light
+                : setDefaultValue("light")
+            }
+            labelText={lang.infoPanel["Light general"]}
+            value={light}
+            setValue={setLight}
+          />
+        )}
         <Input
           className={Style.input}
           style={isEdit ? { backgroundColor: COLORS.lightGreen } : {}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a toggle button to show or hide total light data in the MetersData component.
	- Updated FormDataMonth component to conditionally render the total light input based on the new toggle feature.

- **Bug Fixes**
	- Ensured that the total light input field is correctly displayed or hidden based on user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->